### PR TITLE
fix test suite with stack 2.x

### DIFF
--- a/hint.cabal
+++ b/hint.cabal
@@ -41,7 +41,10 @@ test-suite unit-tests
                   directory,
                   filepath,
                   extensible-exceptions,
-                  exceptions >= 0.10.0
+                  exceptions >= 0.10.0,
+
+                  -- packages used by setImports calls
+                  containers
 
   if !os(windows) {
       build-depends: unix >= 2.2.0.0


### PR DESCRIPTION
ghc uses the GHC_ENVIRONMENT variable to find environment files
describing which packages are visible.

When running the tests using "cabal test", no environment file is
created and GHC_ENVIRONMENT remains unset. ghc nevertheless has access
to a number of default packages, including containers, so the test which
imports Data.Map succeeds.

When running the tests using "cabal v2-test", a local environment file
is created, but GHC_ENVIRONMENT remains unset. ghc nevertheless finds
the environment file, which includes all the dependencies listed in the
.cabal file and also all their recursive dependencies, including
containers, so the test which imports Data.Map succeeds.

When running "stack test" using stack 1.9.3, no environment file is
created and GHC_ENVIRONMENT remains unset. So, depending on whether a
local environment file has been created by a previous run of "cabal
v2-test", one of the two scenarios above occurs, and the test succeeds.

When running "stack test" using stack 2.1.1, a temporary environment
file is created in a temporary directory, and GHC_ENVIRONMENT points to
it. That environment file inludes all the dependencies listed in the
.cabal file, but _not_ their recursive dependencies. Since containers
was not listed in the .cabal file, the test which imports Data.Map
failed.

This commit fixes the problem by adding containers to the .cabal file.

See https://github.com/commercialhaskell/stackage/issues/4668 for
details.