### PR TITLE
Allow building with GHC-8.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,14 @@ matrix:
   include:
     - env: CABALVER=2.0  GHCVER=8.2.2
       addons: {apt: {packages: [cabal-install-2.0,  ghc-8.2.2], sources: [hvr-ghc]}}
-    - env: CABALVER=2.2  GHCVER=8.4.3
-      addons: {apt: {packages: [cabal-install-2.2,  ghc-8.4.3], sources: [hvr-ghc]}}
-    - env: CABALVER=2.4  GHCVER=8.6.1
-      addons: {apt: {packages: [cabal-install-2.4,  ghc-8.6.1], sources: [hvr-ghc]}}
-    - env: CABALVER=2.4  GHCVER=8.6.1 CONFIG_OPTS=--enable-executable-dynamic
-      addons: {apt: {packages: [cabal-install-2.4,  ghc-8.6.1], sources: [hvr-ghc]}}
+    - env: CABALVER=2.2  GHCVER=8.4.4
+      addons: {apt: {packages: [cabal-install-2.2,  ghc-8.4.4], sources: [hvr-ghc]}}
+    - env: CABALVER=2.4  GHCVER=8.6.5
+      addons: {apt: {packages: [cabal-install-2.4,  ghc-8.6.5], sources: [hvr-ghc]}}
+    - env: CABALVER=2.4  GHCVER=8.8.1
+      addons: {apt: {packages: [cabal-install-2.4,  ghc-8.8.1], sources: [hvr-ghc]}}
+    - env: CABALVER=2.4  GHCVER=8.8.1 CONFIG_OPTS=--enable-executable-dynamic
+      addons: {apt: {packages: [cabal-install-2.4,  ghc-8.8.1], sources: [hvr-ghc]}}
 
 cache:
   directories:

--- a/hint.cabal
+++ b/hint.cabal
@@ -54,7 +54,7 @@ test-suite unit-tests
 
 library
   build-depends: base == 4.*,
-                 ghc >= 8.2 && < 8.8,
+                 ghc >= 8.2 && < 8.9,
                  ghc-paths,
                  ghc-boot,
                  mtl,
@@ -63,7 +63,7 @@ library
                  random,
                  directory
 
-  if impl(ghc >= 8.4 && < 8.8) {
+  if impl(ghc >= 8.4 && < 8.9) {
       build-depends: temporary
       cpp-options: -DNEED_PHANTOM_DIRECTORY
   }


### PR DESCRIPTION
The testsuite passes on my machine with `cabal test`
~I was going to add an entry to .travis.yml, but I wasn't sure what to do with the CONFIG_OPTS.~
Edit: it now tests and passes 8.8.1 on travis as well.