### PR TITLE
test search path, fixes #97

### DIFF
--- a/hint.cabal
+++ b/hint.cabal
@@ -46,7 +46,7 @@ test-suite unit-tests
                   -- packages used by setImports calls
                   containers
 
-  if impl(ghc >= 8.4 && < 8.9) {
+  if impl(ghc >= 8.4) {
       build-depends: temporary
       cpp-options: -DNEED_PHANTOM_DIRECTORY
   }

--- a/hint.cabal
+++ b/hint.cabal
@@ -46,10 +46,6 @@ test-suite unit-tests
                   -- packages used by setImports calls
                   containers
 
-  if impl(ghc >= 8.4) {
-      build-depends: temporary
-      cpp-options: -DNEED_PHANTOM_DIRECTORY
-  }
   if impl(ghc >= 8.10) {
       cpp-options: -DTHREAD_SAFE_LINKER
   }
@@ -69,12 +65,9 @@ library
                  filepath,
                  exceptions == 0.10.*,
                  random,
-                 directory
+                 directory,
+                 temporary
 
-  if impl(ghc >= 8.4 && < 8.9) {
-      build-depends: temporary
-      cpp-options: -DNEED_PHANTOM_DIRECTORY
-  }
   if impl(ghc >= 8.10) {
       cpp-options: -DTHREAD_SAFE_LINKER
   }

--- a/hint.cabal
+++ b/hint.cabal
@@ -40,7 +40,6 @@ test-suite unit-tests
                   HUnit,
                   directory,
                   filepath,
-                  extensible-exceptions,
                   exceptions >= 0.10.0,
                   stm,
 

--- a/src/Hint/Base.hs
+++ b/src/Hint/Base.hs
@@ -60,9 +60,7 @@ data InterpreterError = UnknownError String
 data InterpreterState = St {
                            activePhantoms    :: [PhantomModule],
                            zombiePhantoms    :: [PhantomModule],
-#if defined(NEED_PHANTOM_DIRECTORY)
                            phantomDirectory  :: Maybe FilePath,
-#endif
                            hintSupportModule :: PhantomModule,
                            importQualHackMod :: Maybe PhantomModule,
                            qualImports       :: [ModuleImport],

--- a/src/Hint/Configuration.hs
+++ b/src/Hint/Configuration.hs
@@ -17,9 +17,7 @@ module Hint.Configuration (
 import Control.Monad
 import Control.Monad.Catch
 import Data.Char
-#if defined(NEED_PHANTOM_DIRECTORY)
 import Data.Maybe (maybe)
-#endif
 import Data.List (intercalate)
 
 import qualified Hint.GHC as GHC
@@ -124,11 +122,10 @@ searchPath = Option setter getter
           setter p = do onConf $ \c -> c{searchFilePath = p}
                         setGhcOption "-i" -- clear the old path
                         setGhcOption $ "-i" ++ intercalate ":" p
-#if defined(NEED_PHANTOM_DIRECTORY)
+
                         mfp <- fromState phantomDirectory
                         maybe (return ())
                               (\fp -> setGhcOption $ "-i" ++ fp) mfp
-#endif
 
 fromConf :: MonadInterpreter m => (InterpreterConfiguration -> a) -> m a
 fromConf f = fromState (f . configuration)

--- a/src/Hint/Context.hs
+++ b/src/Hint/Context.hs
@@ -32,11 +32,9 @@ import System.Random
 import System.FilePath
 import System.Directory
 
-#if defined(NEED_PHANTOM_DIRECTORY)
 import Data.Maybe (maybe)
 import Hint.Configuration (setGhcOption)
 import System.IO.Temp
-#endif
 
 type ModuleText = String
 
@@ -62,7 +60,6 @@ newPhantomModule =
 
 getPhantomDirectory :: MonadInterpreter m => m FilePath
 getPhantomDirectory =
-#if defined(NEED_PHANTOM_DIRECTORY)
     -- When a module is loaded by file name, ghc-8.4.1 loses track of the
     -- file location after the first time it has been loaded, so we create
     -- a directory for the phantom modules and add it to the search path.
@@ -74,9 +71,6 @@ getPhantomDirectory =
                          onState (\s -> s{ phantomDirectory = Just fp })
                          setGhcOption $ "-i" ++ fp
                          return fp
-#else
-    liftIO getTemporaryDirectory
-#endif
 
 allModulesInContext :: MonadInterpreter m => m ([ModuleName], [ModuleName])
 allModulesInContext = runGhc getContextNames
@@ -362,11 +356,10 @@ cleanPhantomModules =
                         importQualHackMod = Nothing,
                         qualImports         = []})
        liftIO $ mapM_ (removeFile . pmFile) (old_active ++ old_zombie)
-#if defined(NEED_PHANTOM_DIRECTORY)
+
        old_phantomdir <- fromState phantomDirectory
        onState (\s -> s{phantomDirectory    = Nothing})
        liftIO $ do maybe (return ()) removeDirectory old_phantomdir
-#endif
 
 -- | All imported modules are cleared from the context, and
 --   loaded modules are unloaded. It is similar to a @:load@ in

--- a/src/Hint/GHC.hs
+++ b/src/Hint/GHC.hs
@@ -1,17 +1,12 @@
 module Hint.GHC (
-    Message, module X,
-#if __GLASGOW_HASKELL__ < 804
-    GhcPs, mgModSummaries
-#endif
+    Message, module X
 ) where
 
 import GHC as X hiding (Phase, GhcT, runGhcT)
 import Control.Monad.Ghc as X (GhcT, runGhcT)
 
 import HscTypes as X (SourceError, srcErrorMessages, GhcApiError)
-#if __GLASGOW_HASKELL__ >= 804
 import HscTypes as X (mgModSummaries)
-#endif
 
 import Outputable as X (PprStyle, SDoc, Outputable(ppr),
                         showSDoc, showSDocForUser, showSDocUnqual,
@@ -42,10 +37,3 @@ import SrcLoc as X (combineSrcSpans, mkRealSrcLoc)
 import ConLike as X (ConLike(RealDataCon))
 
 type Message = MsgDoc
-
-#if __GLASGOW_HASKELL__ < 804
-type GhcPs = RdrName
-
-mgModSummaries :: ModuleGraph -> [ModSummary]
-mgModSummaries = id
-#endif

--- a/src/Hint/InterpreterT.hs
+++ b/src/Hint/InterpreterT.hs
@@ -161,9 +161,7 @@ initialState :: InterpreterState
 initialState = St {
                    activePhantoms    = [],
                    zombiePhantoms    = [],
-#if defined(NEED_PHANTOM_DIRECTORY)
                    phantomDirectory  = Nothing,
-#endif
                    hintSupportModule = error "No support module loaded!",
                    importQualHackMod = Nothing,
                    qualImports       = [],

--- a/src/Hint/Parsers.hs
+++ b/src/Hint/Parsers.hs
@@ -35,11 +35,7 @@ runParser parser expr =
                                        err = GHC.vcat $ GHC.pprErrMsgBagWithLoc errMsgs
                                    in pure (ParseError span err)
 #else
-#if __GLASGOW_HASKELL__ >= 804
            GHC.PFailed _ span err
-#else
-           GHC.PFailed span err
-#endif
                                 -> return (ParseError span err)
 #endif
 

--- a/unit-tests/run-unit-tests.hs
+++ b/unit-tests/run-unit-tests.hs
@@ -2,7 +2,7 @@ module Main (main) where
 
 import Prelude hiding (catch)
 
-import Control.Exception.Extensible (ArithException(..), AsyncException(UserInterrupt))
+import Control.Exception (ArithException(..), AsyncException(UserInterrupt))
 import Control.Monad.Catch as MC
 
 import Control.Monad (guard, liftM, when, void, (>=>))

--- a/unit-tests/run-unit-tests.hs
+++ b/unit-tests/run-unit-tests.hs
@@ -341,7 +341,7 @@ tests = [test_reload_modified
         ,test_show_in_scope
         ,test_installed_not_in_scope
         ,test_priv_syms_in_scope
-        --,test_search_path  -- TODO: re-enable this test
+        ,test_search_path
         ,test_search_path_dot
         ,test_catch
 #ifndef THREAD_SAFE_LINKER


### PR DESCRIPTION
Each time we suppport a new version of ghc, it takes us a while to figure out why the tests are failing, until we notice that upper bound in `cabal.hint` and bump it up. I see no reason for a restrictive upper bound here, so let's just remove the upper bound to make supporting new versions of ghc easier.