### PR TITLE
I guess I'm the de-facto maintainer now

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+Feel free to open an issue or a PR, but please don't be upset if it lingers for
+a long time. While hint does have a few contributors (the most active
+contributor is listed as the maintainer), we are all busy with other projects
+and none of us wants hint to be among their primary responsibilities. So the
+best way you could contribute would be by becoming the new maintainer :)

--- a/hint.cabal
+++ b/hint.cabal
@@ -14,7 +14,7 @@ category:     Language, Compilers/Interpreters
 license:      BSD3
 license-file: LICENSE
 author:       The Hint Authors
-maintainer:   mvdan@mvdan.cc
+maintainer:   "Samuel Gélineau" <gelisam@gmail.com>
 homepage:     https://github.com/haskell-hint/hint
 
 cabal-version: >= 1.9.2


### PR DESCRIPTION
As explained [here](https://github.com/haskell-hint/hint/issues/68#issuecomment-644811561), I don't really _want_ to be the official maintainer for this project, but since I am the most active contributor, it does make sense to put my name there rather than @mvdan's. But I want to make it absolutely clear that I am not guaranteeing a prompt response on any issues, so I also added a `CONTRIBUTING.md` file stating as much.