### PR TITLE
Support GHC 9.0.1

### DIFF
--- a/hint.cabal
+++ b/hint.cabal
@@ -58,7 +58,7 @@ test-suite unit-tests
 
 library
   build-depends: base == 4.*,
-                 ghc >= 8.4 && < 8.11,
+                 ghc >= 8.4 && < 9.2,
                  ghc-paths,
                  ghc-boot,
                  transformers,

--- a/src/Hint/Annotations.hs
+++ b/src/Hint/Annotations.hs
@@ -4,13 +4,20 @@ module Hint.Annotations (
 ) where
 
 import Data.Data
-import Annotations
 import GHC.Serialized
-import MonadUtils (concatMapM)
 
 import Hint.Base
-import HscTypes (hsc_mod_graph, ms_mod)
 import qualified Hint.GHC as GHC
+
+#if MIN_VERSION_ghc(9,0,0)
+import GHC.Driver.Types (hsc_mod_graph, ms_mod)
+import GHC.Types.Annotations
+import GHC.Utils.Monad (concatMapM)
+#else
+import Annotations
+import HscTypes (hsc_mod_graph, ms_mod)
+import MonadUtils (concatMapM)
+#endif
 
 -- Get the annotations associated with a particular module.
 getModuleAnnotations :: (Data a, MonadInterpreter m) => a -> String -> m [a]

--- a/src/Hint/Configuration.hs
+++ b/src/Hint/Configuration.hs
@@ -70,7 +70,7 @@ set = mapM_ $ \(opt := val) -> _set opt val
 
 -- | Retrieves the value of an option.
 get :: MonadInterpreter m => Option m a -> m a
-get = _get
+get = \o -> _get o
 
 -- | Language extensions in use by the interpreter.
 --

--- a/src/Hint/GHC.hs
+++ b/src/Hint/GHC.hs
@@ -1,10 +1,44 @@
 module Hint.GHC (
     Message, module X
+#if MIN_VERSION_ghc(9,0,0)
+    , dynamicGhc
+#endif
 ) where
 
 import GHC as X hiding (Phase, GhcT, runGhcT)
 import Control.Monad.Ghc as X (GhcT, runGhcT)
 
+#if MIN_VERSION_ghc(9,0,0)
+import GHC.Driver.Types as X (SourceError, srcErrorMessages, GhcApiError)
+-- import GHC.Driver.Types as X (mgModSummaries)
+
+import GHC.Utils.Outputable as X (PprStyle, SDoc, Outputable(ppr),
+                                  showSDoc, showSDocForUser, showSDocUnqual,
+                                  withPprStyle, defaultErrStyle, vcat)
+
+import GHC.Utils.Error as X (mkLocMessage, pprErrMsgBagWithLoc, MsgDoc,
+                             errMsgSpan, pprErrMsgBagWithLoc)
+                             -- we alias MsgDoc as Message below
+
+import GHC.Driver.Phases as X (Phase(Cpp), HscSource(HsSrcFile))
+import GHC.Data.StringBuffer as X (stringToStringBuffer)
+import GHC.Parser.Lexer as X (P(..), ParseResult(..), mkPState,
+                              getErrorMessages)
+import GHC.Parser as X (parseStmt, parseType)
+import GHC.Data.FastString as X (fsLit)
+
+import GHC.Driver.Session as X (xFlags, xopt, LogAction, FlagSpec(..),
+                                WarnReason(NoReason), addWay')
+import GHC.Driver.Ways as X (Way (..), hostIsDynamic)
+
+import GHC.Core.Ppr.TyThing as X (pprTypeForUser)
+import GHC.Types.SrcLoc as X (combineSrcSpans, mkRealSrcLoc)
+
+import GHC.Core.ConLike as X (ConLike(RealDataCon))
+
+dynamicGhc :: Bool
+dynamicGhc = hostIsDynamic
+#else
 import HscTypes as X (SourceError, srcErrorMessages, GhcApiError)
 import HscTypes as X (mgModSummaries)
 
@@ -35,5 +69,6 @@ import PprTyThing as X (pprTypeForUser)
 import SrcLoc as X (combineSrcSpans, mkRealSrcLoc)
 
 import ConLike as X (ConLike(RealDataCon))
+#endif
 
 type Message = MsgDoc

--- a/src/Hint/Parsers.hs
+++ b/src/Hint/Parsers.hs
@@ -54,12 +54,16 @@ failOnParseError parser expr = mayFail go
                              logger <- fromSession ghcErrLogger
                              dflags <- runGhc GHC.getSessionDynFlags
                              let logger'  = logger dflags
+#if !MIN_VERSION_ghc(9,0,0)
                                  errStyle = GHC.defaultErrStyle dflags
+#endif
                              liftIO $ logger'
                                               GHC.NoReason
                                               GHC.SevError
                                               span
+#if !MIN_VERSION_ghc(9,0,0)
                                               errStyle
+#endif
                                               err
                              --
                              -- behave like the rest of the GHC API functions


### PR DESCRIPTION
Sadly, hvr's ubuntu ghc ppa does not include the ghc-9.0.1-rc1. You can test locally with: `cabal test --allow-newer=ghc-paths:Cabal`

I don't know the stance on CPP among `hint` maintainers, so I'm willing to make any suggested style changes wrt conditional compilation.