### PR TITLE
don't try building on ghc-9.0.1 yet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - ghc: latest
+          # TODO: switch to "latest" once ghc-paths bumps its upper bound on
+          # Cabal and we can build with ghc-9.0.1
+          - ghc: 8.10.3
             os: ubuntu-latest
 
     steps:


### PR DESCRIPTION
a temporary fix to get CI to pass. the more permanent fix is for ghc-paths to bump their upper-bounds; there is already a PR for that, we just need to wait for it to get merged.