### PR TITLE
allow building with ghc-9.0.1 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,7 @@ jobs:
     strategy:
       matrix:
         include:
-          # TODO: switch to "latest" once ghc-paths bumps its upper bound on
-          # Cabal and we can build with ghc-9.0.1
-          - ghc: 8.10.3
+          - ghc: latest
             os: ubuntu-latest
 
     steps:


### PR DESCRIPTION
in #113 , we disabled building with ghc-9.0.1 in CI because ghc-paths had a restrictive upper-bound which was led to a build failure because nobuild plan could be found. This issue [has since been fixed in ghc-paths](https://github.com/simonmar/ghc-paths/pull/24), so let's revert #113.