### PR TITLE
 comment that searchPath is not used by loadModules

### DIFF
--- a/src/Hint/Context.hs
+++ b/src/Hint/Context.hs
@@ -189,7 +189,7 @@ isPhantomModule mn = do (as,zs) <- getPhantomModules
 
 -- | Tries to load all the requested modules from their source file.
 --   Modules my be indicated by their ModuleName (e.g. \"My.Module\") or
---   by the full path to its source file.
+--   by the full path to its source file (searchPath is not used).
 --
 -- The interpreter is 'reset' both before loading the modules and in the event
 -- of an error.


### PR DESCRIPTION
I spent lots of time figuring out why searchPath is not working for me.
I was expecting that searchPath prefixes file names of loadModules!
I guess docs should be more obvious about that.