### PR TITLE
remove module description comment block

### DIFF
--- a/hint.cabal
+++ b/hint.cabal
@@ -9,7 +9,7 @@ description:
         It is, essentially, a huge subset of the GHC API wrapped in a simpler
         API.
 
-synopsis:     Runtime Haskell interpreter (GHC API wrapper)
+synopsis:     A Haskell interpreter built on top of the GHC API
 category:     Language, Compilers/Interpreters
 license:      BSD3
 license-file: LICENSE

--- a/src/Language/Haskell/Interpreter.hs
+++ b/src/Language/Haskell/Interpreter.hs
@@ -1,14 +1,3 @@
------------------------------------------------------------------------------
--- |
--- Module      :  Language.Haskell.Interpreter
--- License     :  BSD-style
---
--- Maintainer  :  mvdan@mvdan.cc
--- Stability   :  experimental
--- Portability :  non-portable (GHC API)
---
--- A Haskell interpreter built on top of the GHC API
------------------------------------------------------------------------------
 module Language.Haskell.Interpreter(
     -- * The interpreter monad transformer
      MonadInterpreter(..), InterpreterT, Interpreter,


### PR DESCRIPTION
Barely any of the information it provided was useful.

* 'Module' was redundant with the module name.
* 'License' was redundant with the cabal 'license' field.
* 'Maintainer' was incorrect (see https://github.com/haskell-hint/hint/issues/143).
* 'Stability' doesn't really mean anything, and I haven't tried to update that field to reflect how likely I am to break the API. I try not to make gratuitiously-breaking changes, and I'll follow the PVP if I do decide that breaking backwards-compatibility is worth it.

This leaves two fields, 'Portability' and an anonymous field for the module description:

    Portability :  non-portable (GHC API)

    A Haskell interpreter built on top of the GHC API

* 'Portability' means different things to different people. Hint is portable across operating systems, but not across different GHC versions. I like that the 'Portability' field explains exactly in which way the package is non-portable. The same information is   available from the package summary.
* The module description was describing the package, not the module, and so was redundant with the cabal 'summary' field. I like its wording better than the current summary ("Runtime Haskell interpreter (GHC API wrapper)"), so I've moved it to the cabal file.

Fixes #143 