### PR TITLE
Add test for compilation error capture

### DIFF
--- a/unit-tests/run-unit-tests.hs
+++ b/unit-tests/run-unit-tests.hs
@@ -396,6 +396,19 @@ test_signal_handlers = IOTestCase "signal_handlers" [] $ \wrapInterp -> do
         return r
 #endif
 
+test_error_capture :: IOTestCase
+test_error_capture = IOTestCase "error_capture" [mod_file] $ \wrapInterp-> do
+        liftIO $ writeFile mod_file "$"
+        r <- wrapInterp runInterpreter $ do
+          loadModules [mod_file]
+        case r of
+          Right () -> assertFailure "Loaded invalid file"
+          Left (WontCompile _) -> pure $ Right ()
+          Left e -> assertFailure $ "Got other than WontCompiler error: " ++ show e
+
+    where mod_name = "TEST_ErrorCapture"
+          mod_file = mod_name ++ ".hs"
+
 tests :: [TestCase]
 tests = [test_reload_modified
         ,test_lang_exts
@@ -422,6 +435,7 @@ tests = [test_reload_modified
 ioTests :: [IOTestCase]
 ioTests = [test_signal_handlers
           ,test_package_db
+          ,test_error_capture
           ]
 
 main :: IO ()


### PR DESCRIPTION
Looks like capturing compilation errors only works with some GHCs. Adding a test to try in CI.