### PR TITLE
bump LTS versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
           - stack-8.6.5.yaml
           - stack-8.8.4.yaml
           - stack-8.10.7.yaml
-          - stack-9.0.1.yaml
-          - stack-9.2.1.yaml
+          - stack-9.0.2.yaml
+          - stack-9.2.3.yaml
         os:
           - ubuntu-latest
 

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.27
+resolver: lts-18.28
 packages:
 - .
 extra-deps: []

--- a/stack-9.0.1.yaml
+++ b/stack-9.0.1.yaml
@@ -1,5 +1,0 @@
-resolver: nightly-2021-03-13
-compiler: ghc-9.0.1
-packages:
-- .
-extra-deps: []

--- a/stack-9.0.2.yaml
+++ b/stack-9.0.2.yaml
@@ -1,0 +1,5 @@
+resolver: lts-19.16
+compiler: ghc-9.0.2
+packages:
+- .
+extra-deps: []

--- a/stack-9.2.1.yaml
+++ b/stack-9.2.1.yaml
@@ -1,2 +1,0 @@
-resolver: nightly-2021-11-06
-compiler: ghc-9.2.1

--- a/stack-9.2.3.yaml
+++ b/stack-9.2.3.yaml
@@ -1,0 +1,2 @@
+resolver: nightly-2022-07-30
+compiler: ghc-9.2.3


### PR DESCRIPTION
so that we test against the most recent release of each major version of ghc:

    ghc-9.0.1 -> ghc-9.0.2
    ghc-9.2.1 -> ghc-9.2.3