### PR TITLE
0.9.0.6 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
-### 0.9.0.5
+### 0.9.0.6
+
+* Fixes the 0.9.0.5 regression
+* Small fix in documentation (thanks to Ed Behn)
+
+### 0.9.0.5 (deprecated)
 
 * Support GHC 9.2.1
+* Deprecated because it breaks the common pattern of using
+  'unsafeRunInterpreterWithArgs' to load a custom package database.
 
 ### 0.9.0.4
 

--- a/hint.cabal
+++ b/hint.cabal
@@ -1,5 +1,5 @@
 name:         hint
-version:      0.9.0.5
+version:      0.9.0.6
 description:
         This library defines an Interpreter monad. It allows to load Haskell
         modules, browse them, type-check and evaluate strings with Haskell


### PR DESCRIPTION
I accidentally released version 0.9.0.6 from a commit which was on my computer but was not on github. better late than never!