### PR TITLE
hint-0.9.0.7 improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
           - stack-8.8.4.yaml
           - stack-8.10.7.yaml
           - stack-9.0.2.yaml
-          - stack-9.2.3.yaml
-          - stack-9.4.3.yaml
+          - stack-9.2.7.yaml
+          - stack-9.4.5.yaml
           - stack-9.6.1.yaml
         os:
           - ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -30,6 +30,27 @@ below, you can't run two instances of the interpreter simultaneously.
 GHC must be installed on the system on which the compiled executable is
 running. There is a workaround for this but [it's not trivial](https://github.com/haskell-hint/hint/issues/80#issuecomment-963109968).
 
+The packages used by the interpreted code must be installed in a package
+database, and hint needs to be told about that package database at runtime.
+
+The most common use case for package databases is for the interpreted code to
+have access to the same packages as the compiled code (but not compiled code
+itself). The easiest way to accomplish this is via a
+[GHC environment file](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/packages.html#package-environments),
+and the easiest way to generate a GHC environment file is
+[via cabal](https://cabal.readthedocs.io/en/3.4/cabal-project.html#cfg-field-write-ghc-environment-files).
+Compile your code using `cabal build --write-ghc-environment-files=always`;
+this will create a file named `.ghc.environment.<something>` in the current
+directory. At runtime, hint will look for that file in the current directory.
+
+For more advanced use cases, you can use
+[`unsafeRunInterpreterWithArgs`](https://hackage.haskell.org/package/hint/docs/Language-Haskell-Interpreter-Unsafe.html#v:unsafeRunInterpreterWithArgs)
+to pass arguments to the underlying ghc library, such as
+[`-package-db`](https://downloads.haskell.org/~ghc/latest/docs/users_guide/packages.html?highlight=package%20db#ghc-flag--package-db%20%E2%9F%A8file%E2%9F%A9)
+to specify a path to a package database, or
+[`-package-env`](https://downloads.haskell.org/~ghc/latest/docs/users_guide/packages.html?highlight=package%20db#ghc-flag--package-env%20%E2%9F%A8file%E2%9F%A9%7C%E2%9F%A8name%E2%9F%A9)
+to specify a path to a GHC environment file.
+
 ## Example
 
     {-# LANGUAGE LambdaCase, ScopedTypeVariables, TypeApplications #-}

--- a/README.md
+++ b/README.md
@@ -9,14 +9,28 @@ You can choose which modules should be in scope while evaluating these
 expressions, you can browse the contents of those modules, and you can ask for
 the type of the identifiers you're browsing.
 
-It is, essentially, a huge subset of the GHC API wrapped in a simpler API.
+It is, essentially, a subset of the GHC API wrapped in a simpler API.
 
 ## Limitations
+
+Importing a module from the current package is not supported. It might look
+like it works on one day and then segfault the next day. You have been warned.
+
+To work around this limitation, move those modules to a separate package. Now
+the part of your code which calls hint and the code interpreted by hint can
+both import that module.
+
+It is not possible to exchange a value [whose type involves an implicit kind
+parameter](https://github.com/haskell-hint/hint/issues/159#issuecomment-1575629607).
+This includes type-level lists. To work around this limitation, [define a
+newtype wrapper which wraps the type you
+want](https://github.com/haskell-hint/hint/issues/159#issuecomment-1575640606).
 
 It is possible to run the interpreter inside a thread, but on GHC 8.8 and
 below, you can't run two instances of the interpreter simultaneously.
 
-GHC must be installed on the system on which the compiled executable is running.
+GHC must be installed on the system on which the compiled executable is
+running. There is a workaround for this but [it's not trivial](https://github.com/haskell-hint/hint/issues/80#issuecomment-963109968).
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ You can choose which modules should be in scope while evaluating these
 expressions, you can browse the contents of those modules, and you can ask for
 the type of the identifiers you're browsing.
 
-It is, essentially, a subset of the GHC API wrapped in a simpler API.
-
 ## Limitations
 
 Importing a module from the current package is not supported. It might look

--- a/hint.cabal
+++ b/hint.cabal
@@ -16,6 +16,13 @@ license-file: LICENSE
 author:       The Hint Authors
 maintainer:   "Samuel Gélineau" <gelisam@gmail.com>
 homepage:     https://github.com/haskell-hint/hint
+tested-with:  ghc == 8.10.7
+            , ghc == 8.6.5
+            , ghc == 8.8.4
+            , ghc == 9.0.2
+            , ghc == 9.2.7
+            , ghc == 9.4.5
+            , ghc == 9.6.1
 
 cabal-version: >= 1.10
 build-type:    Simple

--- a/src/Hint/Context.hs
+++ b/src/Hint/Context.hs
@@ -120,12 +120,12 @@ addPhantomModule mod_text =
        liftIO $ writeFile (pmFile pm) (mod_text $ pmName pm)
        --
        onState (\s -> s{activePhantoms = pm:activePhantoms s})
-       mayFail (do -- GHC.loadPhantomModule will remove all the modules from
+       mayFail (do -- GHC.load will remove all the modules from
                    -- scope, so first we save the context...
                    (old_top, old_imps) <- runGhc getContext
                    --
                    runGhc $ GHC.addTarget t
-                   res <- runGhc $ GHC.loadPhantomModule m
+                   res <- runGhc $ GHC.load GHC.LoadAllTargets
                    --
                    if isSucceeded res
                      then do runGhc $ setContext old_top old_imps

--- a/src/Hint/Context.hs
+++ b/src/Hint/Context.hs
@@ -120,8 +120,8 @@ addPhantomModule mod_text =
        liftIO $ writeFile (pmFile pm) (mod_text $ pmName pm)
        --
        onState (\s -> s{activePhantoms = pm:activePhantoms s})
-       mayFail (do -- GHC.load will remove all the modules from scope, so first
-                   -- we save the context...
+       mayFail (do -- GHC.loadPhantomModule will remove all the modules from
+                   -- scope, so first we save the context...
                    (old_top, old_imps) <- runGhc getContext
                    --
                    runGhc $ GHC.addTarget t

--- a/src/Hint/GHC.hs
+++ b/src/Hint/GHC.hs
@@ -28,7 +28,6 @@ module Hint.GHC (
     errMsgSpan,
     fileTarget,
     guessTarget,
-    loadPhantomModule,
 #if MIN_VERSION_ghc(9,6,0)
     getPrintUnqual,
 #endif
@@ -136,8 +135,8 @@ import ConLike as X (ConLike(RealDataCon))
 {-------------------- Imports for Shims --------------------}
 
 import Control.Monad.IO.Class (MonadIO)
--- guessTarger
-import qualified GHC (LoadHowMuch(..), SuccessFlag, guessTarget, load)
+-- guessTarget
+import qualified GHC (guessTarget)
 
 #if MIN_VERSION_ghc(9,6,0)
 -- dynamicGhc
@@ -197,9 +196,6 @@ import qualified GHC.Driver.Phases as GHC (Phase(Cpp))
 import qualified GHC.Driver.Session as GHC (homeUnitId_)
 import qualified GHC.Types.SourceFile as GHC (HscSource(HsSrcFile))
 import qualified GHC.Types.Target as GHC (Target(Target), TargetId(TargetFile))
-
--- loadPhantomModule
-import qualified Language.Haskell.Syntax.Module.Name as GHC (ModuleName)
 
 -- getPrintUnqual
 import qualified GHC (getNamePprCtx)
@@ -261,8 +257,6 @@ import qualified GHC.Driver.Session as GHC (homeUnitId_)
 import qualified GHC.Types.SourceFile as GHC (HscSource(HsSrcFile))
 import qualified GHC.Types.Target as GHC (Target(Target), TargetId(TargetFile))
 
--- loadPhantomModule
-import qualified GHC.Unit.Module.Name as GHC (ModuleName)
 #elif MIN_VERSION_ghc(9,2,0)
 -- dynamicGhc
 import GHC.Platform.Ways (hostIsDynamic)
@@ -317,8 +311,6 @@ import qualified GHC.Driver.Phases as GHC (Phase(Cpp))
 import qualified GHC.Types.SourceFile as GHC (HscSource(HsSrcFile))
 import qualified GHC.Types.Target as GHC (Target(Target), TargetId(TargetFile))
 
--- loadPhantomModule
-import qualified GHC.Unit.Module.Name as GHC (ModuleName)
 #elif MIN_VERSION_ghc(9,0,0)
 -- dynamicGhc
 import GHC.Driver.Ways (hostIsDynamic)
@@ -363,8 +355,6 @@ import qualified GHC.Utils.Error as GHC (errMsgSpan)
 import qualified GHC.Driver.Phases as GHC (HscSource(HsSrcFile), Phase(Cpp))
 import qualified GHC.Driver.Types as GHC (Target(Target), TargetId(TargetFile))
 
--- loadPhantomModule
-import qualified GHC.Unit.Module.Name as GHC (ModuleName)
 #else
 -- dynamicGhc
 import qualified DynFlags as GHC (dynamicGhc)
@@ -414,8 +404,6 @@ import qualified ErrUtils as GHC (errMsgSpan)
 import qualified DriverPhases as GHC (HscSource(HsSrcFile), Phase(Cpp))
 import qualified HscTypes as GHC (Target(Target), TargetId(TargetFile))
 
--- loadPhantomModule
-import qualified Module as GHC (ModuleName)
 #endif
 
 {-------------------- Shims --------------------}
@@ -658,13 +646,6 @@ guessTarget :: GhcMonad m => String -> Maybe GHC.Phase -> m GHC.Target
 guessTarget t pM = GHC.guessTarget t Nothing pM
 #else
 guessTarget = GHC.guessTarget
-#endif
-
-loadPhantomModule :: GhcMonad m => GHC.ModuleName -> m GHC.SuccessFlag
-#if MIN_VERSION_ghc(9,4,0)
-loadPhantomModule _ = GHC.load GHC.LoadAllTargets
-#else
-loadPhantomModule m = GHC.load (GHC.LoadUpTo m)
 #endif
 
 -- getPrintUnqual

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -1,4 +1,6 @@
 resolver: lts-18.28
 packages:
 - .
-extra-deps: []
+extra-deps:
+  # for the ghc-environment-file test
+  - acme-dont-1.2

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -1,4 +1,6 @@
 resolver: lts-14.27
 packages:
 - .
-extra-deps: []
+extra-deps:
+  # for the ghc-environment-file test
+  - acme-dont-1.2

--- a/stack-8.8.4.yaml
+++ b/stack-8.8.4.yaml
@@ -1,4 +1,6 @@
 resolver: lts-16.31
 packages:
 - .
-extra-deps: []
+extra-deps:
+  # for the ghc-environment-file test
+  - acme-dont-1.2

--- a/stack-9.2.3.yaml
+++ b/stack-9.2.3.yaml
@@ -1,2 +1,0 @@
-resolver: nightly-2022-07-30
-compiler: ghc-9.2.3

--- a/stack-9.2.7.yaml
+++ b/stack-9.2.7.yaml
@@ -1,4 +1,4 @@
-resolver: lts-19.33
+resolver: lts-20.24
 packages:
 - .
 extra-deps:

--- a/stack-9.4.3.yaml
+++ b/stack-9.4.3.yaml
@@ -1,2 +1,0 @@
-resolver: nightly-2022-11-29
-compiler: ghc-9.4.3

--- a/stack-9.4.5.yaml
+++ b/stack-9.4.5.yaml
@@ -1,4 +1,5 @@
-resolver: lts-19.33
+resolver: nightly-2023-05-23
+compiler: ghc-9.4.5
 packages:
 - .
 extra-deps:

--- a/stack-9.6.1.yaml
+++ b/stack-9.6.1.yaml
@@ -1,2 +1,7 @@
 resolver: nightly-2023-05-23
 compiler: ghc-9.6.1
+packages:
+- .
+extra-deps:
+  # for the ghc-environment-file test
+  - acme-dont-1.2

--- a/unit-tests/run-unit-tests.hs
+++ b/unit-tests/run-unit-tests.hs
@@ -446,6 +446,8 @@ test_ghc_environment_file = IOTestCase "ghc_environment_file" [dir] $ \wrapInter
                           ]
                         env <- getEnvironment
                         runProcess_
+                          $ proc "cabal" ["update"]
+                        runProcess_
                           $ setWorkingDir dir
                           $ -- stack sets GHC_PACKAGE_PATH, but cabal complains
                             -- that it cannot run if that variable is set.

--- a/unit-tests/run-unit-tests.hs
+++ b/unit-tests/run-unit-tests.hs
@@ -209,7 +209,7 @@ test_search_path_dot =
 test_catch :: TestCase
 test_catch = TestCase "catch" [] $ do
         setImports ["Prelude"]
-        succeeds (action `catch` handler) @@? "catch failed"
+        (action `catch` handler) @@?= "catched"
     where handler DivideByZero = return "catched"
           handler e = throwM e
           action = do s <- eval "1 `div` 0 :: Int"


### PR DESCRIPTION
I want to make a release with #152 and #158, but I would like to address a few low-hanging fruits first:

- [x] document the ghc-environment-files workflow
- [x] document that loading modules from the current package is not supported
- [x] #105

And if I have time (probably not):

- [x] test the ghc-environment-files workflow
- [x] test the catch around `setImports` workflow
- [x] simplify `reinstallSupportModule` to only load the targets once
