### PR TITLE
Hint.Eval: add runStmt' which only warns on compilation error

### DIFF
--- a/src/Language/Haskell/Interpreter.hs
+++ b/src/Language/Haskell/Interpreter.hs
@@ -27,7 +27,7 @@ module Language.Haskell.Interpreter(
      typeChecksWithDetails,
      typeOf, typeChecks, kindOf, normalizeType,
     -- ** Evaluation
-     interpret, as, infer, eval, runStmt,
+     interpret, as, infer, eval, runStmt, runStmt',
     -- * Error handling
      InterpreterError(..), GhcError(..), MultipleInstancesNotAllowed(..),
     -- * Miscellaneous


### PR DESCRIPTION
Sometimes you don't want to give up after a compilation error.
`runStmt'` allows an interpreter to continue after a compilation error.

I am trying to use it in `hwk` for some of its modes.