### PR TITLE
Allow building with ghc-9.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
         include:
           - ghc-version: '9.8.1'
             os: ubuntu-latest
+          - ghc-version: '9.10.1'
+            os: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/hint.cabal
+++ b/hint.cabal
@@ -24,6 +24,7 @@ tested-with:  ghc == 8.10.7
             , ghc == 9.4.5
             , ghc == 9.6.1
             , ghc == 9.8.1
+            , ghc == 9.10.1
 
 cabal-version: >= 1.10
 build-type:    Simple
@@ -72,7 +73,7 @@ library
   default-language: Haskell2010
   build-depends: base == 4.*,
                  containers,
-                 ghc >= 8.4 && < 9.9,
+                 ghc >= 8.4 && < 9.11,
                  ghc-paths,
                  ghc-boot,
                  transformers,


### PR DESCRIPTION
This passes the Cabal/GHC-9.10.1 CI job, although it appears that earlier jobs are broken due to preexisting circumstances.