### PR TITLE
Add support for GHC 9.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - ghc-version: '9.10.1'
+          - ghc-version: '9.12.1'
             os: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### NEXT_RELEASE
 
-* Support GHC 9.10
+* Support GHC 9.10 and GHC 9.12
 
 ### 0.9.0.8
 

--- a/hint.cabal
+++ b/hint.cabal
@@ -25,6 +25,7 @@ tested-with:  ghc == 8.10.7
             , ghc == 9.6.1
             , ghc == 9.8.1
             , ghc == 9.10.1
+            , ghc == 9.12.1
 
 cabal-version: >= 1.10
 build-type:    Simple
@@ -73,7 +74,7 @@ library
   default-language: Haskell2010
   build-depends: base == 4.*,
                  containers,
-                 ghc >= 8.4 && < 9.11,
+                 ghc >= 8.4 && < 9.13,
                  ghc-paths,
                  ghc-boot,
                  transformers,


### PR DESCRIPTION
Compare #173. Once again, this is a pure version bump, so for hackage, a revision is enough.