### PR TITLE
Remove noncanonical definitions

### DIFF
--- a/src/Control/Monad/Ghc.hs
+++ b/src/Control/Monad/Ghc.hs
@@ -35,7 +35,7 @@ newtype GhcT m a = GhcT { unGhcT :: GHC.GhcT (MTLAdapter m) a }
                  deriving (Functor, Monad, GHC.HasDynFlags)
 
 instance (Functor m, Monad m) => Applicative (GhcT m) where
-  pure  = return
+  pure  = GhcT . pure
   (<*>) = ap
 
 -- adapted from https://github.com/ghc/ghc/blob/ghc-8.2/compiler/main/GHC.hs#L450-L459

--- a/src/Hint/InterpreterT.hs
+++ b/src/Hint/InterpreterT.hs
@@ -196,5 +196,5 @@ instance (MonadIO m, MonadMask m, Functor m) => MonadInterpreter (InterpreterT m
     runGhc = runGhcImpl
 
 instance (Monad m) => Applicative (InterpreterT m) where
-    pure  = return
+    pure  = InterpreterT . pure
     (<*>) = ap


### PR DESCRIPTION
This appeases the -Wnoncanonical-monad-instances warning. This warning exists because a future GHC release may treat noncanonical definitions as errors.

See also:
  https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-of-no-return